### PR TITLE
Release v0.3.5 with loopback proxy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to TeXada-the-Math-Agent are recorded here.
 
+## 0.3.5 - 2026-08-01
+
+### English
+
+- Fixed the desktop bridge routing loopback FastAPI requests through the
+  operating system proxy. On proxy-enabled macOS systems this made a healthy
+  backend and Ollama connection appear as `No API`, while formula requests
+  failed with `502 Bad Gateway`.
+- Tauri HTTP clients now disable proxy discovery when the configured TeXada API
+  base uses `localhost`, an IPv4/IPv6 loopback address, or an unspecified local
+  address. Explicit remote API bases retain normal system-proxy support.
+- Added Rust regression tests covering local IPv4, IPv6, and hostname variants,
+  plus remote and malformed API bases. Reproduced the original 502 through the
+  active macOS proxy and verified direct FastAPI and Ollama requests before the
+  fix.
+
+### 中文
+
+- 修复桌面桥接把回环 FastAPI 请求发送到操作系统代理的问题。在启用代理的 macOS
+  上，健康的 TeXada 后端与 Ollama 连接会被显示为 `No API`，公式请求则返回
+  `502 Bad Gateway`。
+- 当 TeXada API 地址使用 `localhost`、IPv4/IPv6 回环地址或未指定的本地地址时，
+  Tauri HTTP 客户端现在会禁用代理发现；显式配置的远程 API 地址仍保留正常的系统
+  代理支持。
+- 新增 Rust 回归测试，覆盖本地 IPv4、IPv6、主机名、远程地址和非法地址。修复前
+  已通过当前 macOS 代理复现 502，并分别验证 FastAPI 与 Ollama 直连正常。
+
 ## 0.3.4 - 2026-07-31
 
 ### English

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ The Ollama port is configurable. The default is `http://localhost:11434`, but Se
 
 ### Download
 
-Version `0.3.4` is released from the `main` branch.
+Version `0.3.5` is released from the `main` branch.
 
 | Platform | Package |
 |----------|---------|
-| macOS Apple Silicon | `TeXada_0.3.4_aarch64.dmg` |
-| macOS Intel | `TeXada_0.3.4_x64.dmg` |
-| Windows x64 | `TeXada_0.3.4_x64-setup.exe` |
+| macOS Apple Silicon | `TeXada_0.3.5_aarch64.dmg` |
+| macOS Intel | `TeXada_0.3.5_x64.dmg` |
+| Windows x64 | `TeXada_0.3.5_x64-setup.exe` |
 
 Release page: [github.com/CacinieP/TeXada-the-Math-Agent/releases](https://github.com/CacinieP/TeXada-the-Math-Agent/releases)
 
@@ -415,13 +415,13 @@ Ollama 端口不是写死的。默认地址是 `http://localhost:11434`，但可
 
 ### 下载
 
-版本 `0.3.4` 从 `main` 分支发布。
+版本 `0.3.5` 从 `main` 分支发布。
 
 | 平台 | 安装包 |
 |------|--------|
-| macOS Apple Silicon | `TeXada_0.3.4_aarch64.dmg` |
-| macOS Intel | `TeXada_0.3.4_x64.dmg` |
-| Windows x64 | `TeXada_0.3.4_x64-setup.exe` |
+| macOS Apple Silicon | `TeXada_0.3.5_aarch64.dmg` |
+| macOS Intel | `TeXada_0.3.5_x64.dmg` |
+| Windows x64 | `TeXada_0.3.5_x64-setup.exe` |
 
 Release 页面：[github.com/CacinieP/TeXada-the-Math-Agent/releases](https://github.com/CacinieP/TeXada-the-Math-Agent/releases)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "texada-the-math-agent",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "texada-the-math-agent",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "katex": "0.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "texada-the-math-agent",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Local math formula agent powered by MiniCPM",
   "repository": {
     "type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "texada"
-version = "0.3.4"
+version = "0.3.5"
 description = "Local math formula agent powered by MiniCPM"
 license = "GPL-3.0-or-later"
 requires-python = ">=3.12"

--- a/src/texada/__init__.py
+++ b/src/texada/__init__.py
@@ -4,4 +4,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("texada")
 except PackageNotFoundError:
-    __version__ = "0.3.4"
+    __version__ = "0.3.5"

--- a/src/texada/api.py
+++ b/src/texada/api.py
@@ -226,7 +226,7 @@ def _app_version() -> str:
     try:
         return version("texada")
     except PackageNotFoundError:
-        return "0.3.4"
+        return "0.3.5"
 
 
 def _settings_response(config: TeXadaConfig) -> BackendSettingsResponse:

--- a/tauri-shell/src-tauri/Cargo.lock
+++ b/tauri-shell/src-tauri/Cargo.lock
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "texada-shell"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/tauri-shell/src-tauri/Cargo.toml
+++ b/tauri-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "texada-shell"
-version = "0.3.4"
+version = "0.3.5"
 description = "TeXada floating shell — math formula agent"
 authors = ["TeXada"]
 license = "GPL-3.0-or-later"

--- a/tauri-shell/src-tauri/src/main.rs
+++ b/tauri-shell/src-tauri/src/main.rs
@@ -87,20 +87,6 @@ fn saved_request_timeout_secs() -> Option<u64> {
     }
 }
 
-fn http_client() -> Result<reqwest::Client, String> {
-    reqwest::Client::builder()
-        .timeout(request_timeout())
-        .build()
-        .map_err(|e| format!("HTTP client setup failed: {}", e))
-}
-
-fn startup_probe_client() -> Result<reqwest::Client, String> {
-    reqwest::Client::builder()
-        .timeout(Duration::from_millis(BACKEND_STARTUP_PROBE_MS))
-        .build()
-        .map_err(|e| format!("HTTP client setup failed: {}", e))
-}
-
 fn env_flag_enabled(name: &str) -> bool {
     env::var(name)
         .map(|value| {
@@ -113,12 +99,47 @@ fn env_flag_enabled(name: &str) -> bool {
 }
 
 fn is_local_api_host(host: &str) -> bool {
+    let host = host
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host);
     if host.eq_ignore_ascii_case("localhost") {
         return true;
     }
     host.parse::<IpAddr>()
         .map(|addr| addr.is_loopback() || addr.is_unspecified())
         .unwrap_or(false)
+}
+
+fn is_local_api_base(value: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(value.trim()) else {
+        return false;
+    };
+    url.host_str().map(is_local_api_host).unwrap_or(false)
+}
+
+fn api_client_for_base(timeout: Duration, api_base: &str) -> Result<reqwest::Client, String> {
+    let mut builder = reqwest::Client::builder().timeout(timeout);
+    if is_local_api_base(api_base) {
+        // The desktop bridge only calls this API base. Loopback traffic must
+        // never pass through a macOS or Windows system proxy.
+        builder = builder.no_proxy();
+    }
+    builder
+        .build()
+        .map_err(|e| format!("HTTP client setup failed: {}", e))
+}
+
+fn api_client(timeout: Duration) -> Result<reqwest::Client, String> {
+    api_client_for_base(timeout, &configured_api_base())
+}
+
+fn http_client() -> Result<reqwest::Client, String> {
+    api_client(request_timeout())
+}
+
+fn startup_probe_client() -> Result<reqwest::Client, String> {
+    api_client(Duration::from_millis(BACKEND_STARTUP_PROBE_MS))
 }
 
 fn explicit_api_base_is_remote() -> bool {
@@ -617,4 +638,63 @@ fn main() {
             stop_bundled_backend(app_handle);
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{api_client_for_base, is_local_api_base};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[test]
+    fn local_api_base_detection_covers_loopback_variants() {
+        assert!(is_local_api_base("http://127.0.0.1:18732"));
+        assert!(is_local_api_base("http://localhost:18732/"));
+        assert!(is_local_api_base("http://[::1]:18732"));
+        assert!(is_local_api_base("http://0.0.0.0:18732"));
+        assert!(is_local_api_base("http://[::]:18732"));
+    }
+
+    #[test]
+    fn local_api_base_detection_preserves_proxy_support_for_remote_hosts() {
+        assert!(!is_local_api_base("https://api.example.com/v1"));
+        assert!(!is_local_api_base("http://192.168.1.10:18732"));
+        assert!(!is_local_api_base("not a URL"));
+    }
+
+    #[tokio::test]
+    async fn local_api_client_reaches_loopback_directly() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback test server");
+        let address = listener.local_addr().expect("read loopback address");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept local request");
+            let mut request = [0_u8; 1024];
+            stream.read(&mut request).await.expect("read local request");
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\ndirect",
+                )
+                .await
+                .expect("write local response");
+        });
+
+        let api_base = format!("http://{address}");
+        let client = api_client_for_base(Duration::from_secs(2), &api_base)
+            .expect("build direct local client");
+        let response = client
+            .get(format!("{api_base}/api/status"))
+            .send()
+            .await
+            .expect("request local API without a proxy");
+
+        assert!(response.status().is_success());
+        assert_eq!(
+            response.text().await.expect("read local response"),
+            "direct"
+        );
+        server.await.expect("join loopback test server");
+    }
 }

--- a/tauri-shell/src-tauri/tauri.conf.json
+++ b/tauri-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "TeXada",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "identifier": "com.texada.desktop",
   "build": {
     "frontendDist": "../src",

--- a/tauri-shell/src/index.html
+++ b/tauri-shell/src/index.html
@@ -5,14 +5,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: blob:; connect-src 'self' http://127.0.0.1:* http://localhost:* http://[::1]:*; object-src 'none'; base-uri 'none'; frame-ancestors 'none'">
 <title>TeXada</title>
-<link rel="stylesheet" href="vendor/katex/katex.min.css?v=0.3.4-20260731">
-<link rel="stylesheet" href="style.css?v=0.3.4-20260731">
+<link rel="stylesheet" href="vendor/katex/katex.min.css?v=0.3.5-20260801">
+<link rel="stylesheet" href="style.css?v=0.3.5-20260801">
 </head>
 <body>
 <div id="app">
   <!-- Header -->
   <div class="panel-header" data-tauri-drag-region>
-    <img class="panel-logo" src="app-icon.png?v=0.3.4-20260731" alt="TeXada" data-tauri-drag-region>
+    <img class="panel-logo" src="app-icon.png?v=0.3.5-20260801" alt="TeXada" data-tauri-drag-region>
     <div class="panel-title" data-tauri-drag-region>TeXada</div>
     <div class="panel-status" id="status-dot" data-tauri-drag-region>
       <div class="dot offline"></div>
@@ -345,14 +345,14 @@
       <div class="settings-title" data-i18n="settings.about">关于</div>
       <div class="setting-row">
         <div class="setting-label">TeXada Shell</div>
-        <div class="setting-value">v0.3.4</div>
+        <div class="setting-value">v0.3.5</div>
       </div>
     </div>
   </div>
 </div>
 
-<script src="vendor/katex/katex.min.js?v=0.3.4-20260731"></script>
-<script src="api-config.js?v=0.3.4-20260731"></script>
-<script src="main.js?v=0.3.4-20260731"></script>
+<script src="vendor/katex/katex.min.js?v=0.3.5-20260801"></script>
+<script src="api-config.js?v=0.3.5-20260801"></script>
+<script src="main.js?v=0.3.5-20260801"></script>
 </body>
 </html>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,7 +65,7 @@ def test_release_version_is_synchronized_across_python_node_and_tauri():
         uv_lock_version,
         __version__,
         _app_version(),
-    } == {"0.3.4"}
+    } == {"0.3.5"}
     assert f"v{python_version}" in frontend
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -945,7 +945,7 @@ wheels = [
 
 [[package]]
 name = "texada"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## What changed

- bypass operating-system proxy discovery for loopback TeXada API bases in the Tauri desktop bridge
- retain normal proxy support for explicitly configured remote API bases
- add IPv4, IPv6, hostname, remote-base, malformed-base, and real loopback HTTP regression coverage
- bump synchronized desktop/backend/package versions to 0.3.5 and add bilingual release notes

## Root cause

On proxy-enabled macOS systems, the Tauri reqwest client sent 127.0.0.1:18732 traffic through the system proxy. The FastAPI sidecar and Ollama were healthy, but the proxy returned 502 Bad Gateway, so the desktop UI showed No API.

## Validation

- 299 Python tests passed; 8 optional tests skipped
- Ruff passed
- Rust cargo check passed
- 3 Rust regression tests passed, including a real loopback HTTP request with the active macOS system proxy
- npm audit: 0 vulnerabilities
- pip-audit: no known vulnerabilities
- JavaScript syntax check passed
- local macOS .app bundle built successfully
