### PR TITLE
Release v0.3.6 startup UX fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to TeXada-the-Math-Agent are recorded here.
 
+## 0.3.6 - 2026-08-02
+
+### English
+
+- Removed automatic clipboard reads and natural-language input prefill when the
+  desktop window opens or regains focus. The input now stays empty until the
+  user types, so copied setup commands such as `ollama pull ...` can no longer
+  appear in the formula field.
+- Replaced the misleading transient `No API` state during bundled backend cold
+  starts with `Starting API…`. After the sidecar becomes ready, the existing
+  detailed status remains unchanged and continues to show the endpoint, text
+  model, and vision model.
+- Added frontend regression coverage and verified the packaged flow with
+  Computer Use: a clipboard containing Ollama pull commands left the input
+  empty, cold start transitioned from `Starting API…` to the detailed ready
+  state, and manually entered formulas still completed successfully.
+
+### 中文
+
+- 移除桌面窗口打开或重新获得焦点时自动读取剪贴板并预填自然语言输入框的行为。
+  输入框现在会一直保持空白，直到用户主动输入，因此复制的
+  `ollama pull ...` 等安装命令不会再出现在公式输入框中。
+- 将内置后端冷启动期间容易误解的临时 `No API` 状态改为“API 启动中…”。
+  sidecar 就绪后仍保留原有完整状态详情，继续显示 Endpoint、文本模型和视觉模型。
+- 新增前端回归测试，并通过 Computer Use 验证打包流程：剪贴板包含 Ollama pull
+  命令时输入框仍为空，冷启动会从“API 启动中…”切换到原有详细完成态，用户手动
+  输入的公式仍可正常转换。
+
 ## 0.3.5 - 2026-08-01
 
 ### English

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ The Ollama port is configurable. The default is `http://localhost:11434`, but Se
 
 ### Download
 
-Version `0.3.5` is released from the `main` branch.
+Version `0.3.6` is released from the `main` branch.
 
 | Platform | Package |
 |----------|---------|
-| macOS Apple Silicon | `TeXada_0.3.5_aarch64.dmg` |
-| macOS Intel | `TeXada_0.3.5_x64.dmg` |
-| Windows x64 | `TeXada_0.3.5_x64-setup.exe` |
+| macOS Apple Silicon | `TeXada_0.3.6_aarch64.dmg` |
+| macOS Intel | `TeXada_0.3.6_x64.dmg` |
+| Windows x64 | `TeXada_0.3.6_x64-setup.exe` |
 
 Release page: [github.com/CacinieP/TeXada-the-Math-Agent/releases](https://github.com/CacinieP/TeXada-the-Math-Agent/releases)
 
@@ -415,13 +415,13 @@ Ollama 端口不是写死的。默认地址是 `http://localhost:11434`，但可
 
 ### 下载
 
-版本 `0.3.5` 从 `main` 分支发布。
+版本 `0.3.6` 从 `main` 分支发布。
 
 | 平台 | 安装包 |
 |------|--------|
-| macOS Apple Silicon | `TeXada_0.3.5_aarch64.dmg` |
-| macOS Intel | `TeXada_0.3.5_x64.dmg` |
-| Windows x64 | `TeXada_0.3.5_x64-setup.exe` |
+| macOS Apple Silicon | `TeXada_0.3.6_aarch64.dmg` |
+| macOS Intel | `TeXada_0.3.6_x64.dmg` |
+| Windows x64 | `TeXada_0.3.6_x64-setup.exe` |
 
 Release 页面：[github.com/CacinieP/TeXada-the-Math-Agent/releases](https://github.com/CacinieP/TeXada-the-Math-Agent/releases)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "texada-the-math-agent",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "texada-the-math-agent",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "katex": "0.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "texada-the-math-agent",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Local math formula agent powered by MiniCPM",
   "repository": {
     "type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "texada"
-version = "0.3.5"
+version = "0.3.6"
 description = "Local math formula agent powered by MiniCPM"
 license = "GPL-3.0-or-later"
 requires-python = ">=3.12"

--- a/src/texada/__init__.py
+++ b/src/texada/__init__.py
@@ -4,4 +4,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("texada")
 except PackageNotFoundError:
-    __version__ = "0.3.5"
+    __version__ = "0.3.6"

--- a/tauri-shell/src-tauri/Cargo.lock
+++ b/tauri-shell/src-tauri/Cargo.lock
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "texada-shell"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/tauri-shell/src-tauri/Cargo.toml
+++ b/tauri-shell/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "texada-shell"
-version = "0.3.5"
+version = "0.3.6"
 description = "TeXada floating shell — math formula agent"
 authors = ["TeXada"]
 license = "GPL-3.0-or-later"

--- a/tauri-shell/src-tauri/tauri.conf.json
+++ b/tauri-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "TeXada",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "identifier": "com.texada.desktop",
   "build": {
     "frontendDist": "../src",

--- a/tauri-shell/src/index.html
+++ b/tauri-shell/src/index.html
@@ -5,14 +5,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: blob:; connect-src 'self' http://127.0.0.1:* http://localhost:* http://[::1]:*; object-src 'none'; base-uri 'none'; frame-ancestors 'none'">
 <title>TeXada</title>
-<link rel="stylesheet" href="vendor/katex/katex.min.css?v=0.3.5-20260801">
-<link rel="stylesheet" href="style.css?v=0.3.5-20260801">
+<link rel="stylesheet" href="vendor/katex/katex.min.css?v=0.3.6-20260802">
+<link rel="stylesheet" href="style.css?v=0.3.6-20260802">
 </head>
 <body>
 <div id="app">
   <!-- Header -->
   <div class="panel-header" data-tauri-drag-region>
-    <img class="panel-logo" src="app-icon.png?v=0.3.5-20260801" alt="TeXada" data-tauri-drag-region>
+    <img class="panel-logo" src="app-icon.png?v=0.3.6-20260802" alt="TeXada" data-tauri-drag-region>
     <div class="panel-title" data-tauri-drag-region>TeXada</div>
     <div class="panel-status" id="status-dot" data-tauri-drag-region>
       <div class="dot offline"></div>
@@ -345,14 +345,14 @@
       <div class="settings-title" data-i18n="settings.about">关于</div>
       <div class="setting-row">
         <div class="setting-label">TeXada Shell</div>
-        <div class="setting-value">v0.3.5</div>
+        <div class="setting-value">v0.3.6</div>
       </div>
     </div>
   </div>
 </div>
 
-<script src="vendor/katex/katex.min.js?v=0.3.5-20260801"></script>
-<script src="api-config.js?v=0.3.5-20260801"></script>
-<script src="main.js?v=0.3.5-20260801"></script>
+<script src="vendor/katex/katex.min.js?v=0.3.6-20260802"></script>
+<script src="api-config.js?v=0.3.6-20260802"></script>
+<script src="main.js?v=0.3.6-20260802"></script>
 </body>
 </html>

--- a/tauri-shell/src/main.js
+++ b/tauri-shell/src/main.js
@@ -202,6 +202,7 @@
       'settings.clearConfirm': '确定要清空全部历史记录吗？此操作不可撤销。',
       'settings.clearRunsConfirm': '确定要清空全部运行日志吗？此操作不可撤销。',
       'status.ready': 'Ready',
+      'status.starting': 'API 启动中…',
       'status.noApi': 'No API',
       'status.error': 'Error',
       'status.offline': 'Offline',
@@ -375,6 +376,7 @@
       'settings.clearConfirm': 'Clear all history? This cannot be undone.',
       'settings.clearRunsConfirm': 'Clear all run logs? This cannot be undone.',
       'status.ready': 'Ready',
+      'status.starting': 'Starting API…',
       'status.noApi': 'No API',
       'status.error': 'Error',
       'status.offline': 'Offline',
@@ -668,8 +670,10 @@
     const dot = els.statusDot.querySelector('.dot');
     const span = els.statusDot.querySelector('span');
     dot.className = 'dot';
-    if (!online) dot.classList.add('offline');
-    if (online && state === 'partial_ready') dot.classList.add('warning');
+    if (!online && state !== 'starting') dot.classList.add('offline');
+    if (state === 'starting' || (online && state === 'partial_ready')) {
+      dot.classList.add('warning');
+    }
     span.textContent = text || (online ? t('status.online') : t('status.offline'));
     els.statusDot.title = backendStatusTitle(details);
   }
@@ -729,7 +733,7 @@
     }
   }
 
-  async function checkBackend() {
+  async function checkBackend({ starting = false } = {}) {
     try {
       const info = isTauri ? await invoke('get_status') : await apiJson('/api/status');
       const isOnline = Boolean(info.ready) || info.status === 'ok' || info.status === 'ready' || info.status === 'partial_ready';
@@ -743,10 +747,10 @@
           setStatus(isOnline, backendStatusText(info), info.status, info);
           return isOnline;
         } catch (e2) {
-          setStatus(false, t('status.noApi'));
+          setStatus(false, t(starting ? 'status.starting' : 'status.noApi'), starting ? 'starting' : '');
         }
       } else {
-        setStatus(false, t('status.noApi'));
+        setStatus(false, t(starting ? 'status.starting' : 'status.noApi'), starting ? 'starting' : '');
       }
       return false;
     }
@@ -755,13 +759,15 @@
   function waitForBackendStartup() {
     if (backendStartupPromise) return backendStartupPromise;
     backendStartupPromise = (async () => {
+      setStatus(false, t('status.starting'), 'starting');
       for (let attempt = 0; attempt < 80; attempt += 1) {
         await new Promise(resolve => setTimeout(resolve, 750));
-        if (await checkBackend()) {
+        if (await checkBackend({ starting: true })) {
           await loadRuntimeConfig();
           return true;
         }
       }
+      setStatus(false, t('status.noApi'));
       return false;
     })().finally(() => {
       backendStartupPromise = null;
@@ -1151,22 +1157,6 @@
       await invoke('write_clipboard', { text });
     } else {
       await navigator.clipboard.writeText(text);
-    }
-  }
-
-  async function pasteFromClipboard() {
-    if (isTauri) {
-      try {
-        return await invoke('read_clipboard');
-      } catch (e) {
-        return '';
-      }
-    } else {
-      try {
-        return await navigator.clipboard.readText();
-      } catch (e) {
-        return '';
-      }
     }
   }
 
@@ -2467,16 +2457,11 @@
   await loadRuntimeConfig();
   await loadUiSettings();
 
-  // ── Auto-focus & clipboard on show ──
+  // ── Auto-focus on show ──
   async function onWindowShown() {
-    const ready = await checkBackend();
+    const ready = await checkBackend({ starting: isDesktop });
     if (!ready && isDesktop) waitForBackendStartup();
     if (currentTab === 'nl') {
-      const clip = await pasteFromClipboard();
-      // Only auto-fill if clipboard looks like a math description (heuristic)
-      if (clip && clip.length > 0 && clip.length < 500 && !els.nlInput.value) {
-        els.nlInput.value = clip;
-      }
       els.nlInput.focus();
     }
   }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,7 +65,7 @@ def test_release_version_is_synchronized_across_python_node_and_tauri():
         uv_lock_version,
         __version__,
         _app_version(),
-    } == {"0.3.5"}
+    } == {"0.3.6"}
     assert f"v{python_version}" in frontend
 
 

--- a/tests/test_frontend_contract.py
+++ b/tests/test_frontend_contract.py
@@ -99,6 +99,16 @@ def test_bundled_backend_startup_wait_covers_slow_frozen_imports():
     assert "attempt < 80" in JAVASCRIPT
     assert "window.location.protocol === 'tauri:'" in JAVASCRIPT
     assert "if (!ready && isDesktop) waitForBackendStartup()" in JAVASCRIPT
+    assert "'status.starting': 'API 启动中…'" in JAVASCRIPT
+    assert "checkBackend({ starting: true })" in JAVASCRIPT
+    assert "setStatus(false, t('status.noApi'))" in JAVASCRIPT
+
+
+def test_natural_language_input_is_never_prefilled_from_clipboard():
+    assert "pasteFromClipboard()" not in JAVASCRIPT
+    assert "navigator.clipboard.readText()" not in JAVASCRIPT
+    assert "invoke('read_clipboard')" not in JAVASCRIPT
+    assert "clip.length > 0 && clip.length < 500" not in JAVASCRIPT
 
 
 def test_frozen_sidecar_collects_the_native_katex_runtime():

--- a/uv.lock
+++ b/uv.lock
@@ -945,7 +945,7 @@ wheels = [
 
 [[package]]
 name = "texada"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## What changed

- stop reading and prefilling the natural-language input from the clipboard when the desktop window opens or regains focus
- show `API 启动中…` / `Starting API…` while the bundled backend cold-starts
- preserve the existing detailed Endpoint / Text / Vision ready status after startup
- bump all Python, Node, Tauri, Cargo, frontend, README, and lockfile versions to 0.3.6
- add bilingual v0.3.6 changelog notes and frontend regression coverage

## Why

The previous focus handler treated any short clipboard text as formula input, so copied `ollama pull ...` setup commands appeared in the field. During a healthy sidecar cold start, the UI also briefly reported `No API`, which looked like a connection failure even though polling later succeeded.

## Impact

The input stays empty until the user types. Cold starts now communicate progress without changing the rich completed status details.

## Validation

- `uv run pytest -q` — 300 passed, 8 skipped
- `uv run ruff check src tests`
- `cargo test --manifest-path tauri-shell/src-tauri/Cargo.toml` — 3 passed
- `node --check tauri-shell/src/main.js`
- `uv lock --check`
- `npm audit --audit-level=high --registry=https://registry.npmjs.org` — 0 vulnerabilities
- Computer Use cold-start test with Ollama pull commands in the clipboard: input remained empty, status transitioned from `API 启动中…` to the existing Endpoint / Text / Vision ready state, and manual input completed successfully
